### PR TITLE
Avoid duplicate proposition in completion

### DIFF
--- a/src/gtkcompletionline.c
+++ b/src/gtkcompletionline.c
@@ -444,7 +444,10 @@ static GList * generate_execs_list (char * pfix)
       int j;
       if (n >= 0) {
          for (j = 0; j < n; j++) {
-            execs_gc = g_list_prepend (execs_gc, g_strdup (eps[j]->d_name));
+            // Avoid adding duplicate entries. No need to search for dup while in first PATH entry
+            if (path_gc_i == path_gc || NULL == g_list_find_custom(execs_gc, eps[j]->d_name, (GCompareFunc)g_ascii_strcasecmp)) {
+               execs_gc = g_list_prepend (execs_gc, g_strdup (eps[j]->d_name));
+            }
             free (eps[j]);
          }
          free (eps);


### PR DESCRIPTION
This is a proposition to avoid having duplicate entries in completion menu.
For example, on my distribution, /bin is a symlink to /usr/bin adn both are in PATH.
So every entry in /usr/bin appear twice.
